### PR TITLE
Extract (meta)data from GFM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 /site/
 .DS_Store
 .coverage
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 __pycache__
 /site/
 .DS_Store
+.coverage

--- a/nexis_analysis/cli.py
+++ b/nexis_analysis/cli.py
@@ -70,7 +70,7 @@ def analyse(input_dir: pathlib.Path, output_dir: pathlib.Path):
     if output_dir is None:
         output_dir = input_dir
     output_file = output_dir / "analysis-results.csv"
-    header = ["document","title","publication","date","section","byline","length"]
+    header = ["document","title","publication","date","load_date","section","byline","length"]
     with output_file.open("w", encoding="utf-8", newline="") as a_file:
         writer = csv.DictWriter(a_file, header, extrasaction="ignore")
         writer.writeheader()

--- a/nexis_analysis/cli.py
+++ b/nexis_analysis/cli.py
@@ -76,7 +76,9 @@ def analyse(input_dir: pathlib.Path, output_dir: pathlib.Path):
         writer.writeheader()
         for f in input_dir.glob("*.md"):
             doc = document.doc_from_file(f)
-            writer.writerow(doc.as_dict())
+            doc_dict = doc.as_dict()
+            doc_dict["document"] = f
+            writer.writerow(doc_dict)
 
 
 if __name__ == "__main__":

--- a/nexis_analysis/cli.py
+++ b/nexis_analysis/cli.py
@@ -77,7 +77,7 @@ def analyse(input_dir: pathlib.Path, output_dir: pathlib.Path):
         for f in input_dir.glob("*.md"):
             doc = document.doc_from_file(f)
             doc_dict = doc.as_dict()
-            doc_dict["document"] = f
+            doc_dict["document"] = f.name
             writer.writerow(doc_dict)
 
 

--- a/nexis_analysis/cli.py
+++ b/nexis_analysis/cli.py
@@ -44,7 +44,7 @@ def convert_docx_to_gfm(input_dir: pathlib.Path, output_dir: pathlib.Path):
                 "name_hash": name_hash,
                 "source_file_name": str(item),
                 "source_file_sha256": file_hash,
-                "target_file_name": f"{name_hash}.md"
+                "target_file_name": f"{name_hash}.md",
                 "conversion_rc": conversion_result.returncode,
             })
             file_hashes[file_hash].append(str(item))

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -47,6 +47,10 @@ class NexisDocument(object):
         return extract.get_date(self.raw_source)
 
     @property
+    def load_date(self) -> datetime.datetime:
+        return extract.get_load_date(self.raw_source)
+
+    @property
     def date_str(self) -> str:
         return extract.get_date_str(self.raw_source)
 
@@ -73,6 +77,7 @@ class NexisDocument(object):
             "title": self.title_or_incipit,
             "publication": self.publication if self.publication else "[no publication]",
             "date": self.date.isoformat() if self.date else "[no date]",
+            "load_date": self.load_date.isoformat() if self.load_date else "[no date]",
             "section": self.section if self.section else "[no section]",
             "byline": self.byline if self.byline else "[no byline]",
             "length": self.length if self.length else "[no length]",

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -1,64 +1,21 @@
 # SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Extract information from documents"""
+"""Representation of Nexis Uni documents"""
 import datetime
-import pathlib
-import re
 
-month_by_name = {
-    "januari": 1,
-    "februari": 2,
-    "maart": 3,
-    "april": 4,
-    "mei": 5,
-    "juni": 6,
-    "juli": 7,
-    "augustus": 8,
-    "september": 9,
-    "oktober": 10,
-    "november": 11,
-    "december": 12,
-}
+class NexisDocument(object):
+    body: str
+    title: str
+    length: int
+    date_str: str
+    date: datetime.datetime
+    raw_source: str
 
-class NexisDocument:
-
-    def __init__(self, file_name):
-        """Create a NexisDocument by loading a GFM file"""
-        with open(file_name, "r", encoding="utf-8") as fh:
-            self.raw_source = fh.read()
-
-    @property
-    def body(self):
-
-        body_start = """**Body**"""
-        body_start_index = self.raw_source.index(body_start) + len(body_start)
-        body_end = """**Load-Date:**"""
-        body_end_index = self.raw_source.index(body_end)
-        return self.raw_source[body_start_index:body_end_index].strip()
-
-    @property
-    def title(self):
-        title = re.search(r"# \[\*{3}<u>(.+)</u>\*{3}\]", self.raw_source)
-        if title:
-            return title.group(1).replace("</u>*** ***<u>", " ")
-
-    @property
-    def length(self):
-        length = re.search(r"\*\*Length:\*\*\s(\d+)\swords", self.raw_source)
-        if length:
-            return int(length.group(1))
-
-    @property
-    def date(self):
-        date = re.search(r"(\d\d?) (\w+) (\d{4}) \w+dag", self.raw_source)
-        if date:
-            year = int(date.group(3))
-            month = month_by_name.get(date.group(2).lower())
-            day = int(date.group(1))
-            return datetime.datetime(year, month, day)
-
-    @property
-    def date_str(self):
-        date = re.search(r"(\d\d? \w+ \d{4} \w+dag)", self.raw_source)
-        if date:
-            return date.group(1)
+    def __init__(self, raw_source: str):
+        """Create a NexisDocument from GFM text"""
+        self.raw_source = raw_source
+        self.body = None
+        self.title = None
+        self.length = None
+        self.date_str = None
+        self.date = None

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -65,6 +65,9 @@ class NexisDocument(object):
     def search_terms_in_body_counts(self) -> Counter:
         return extract.get_search_terms_count(self.raw_source)
 
+    def search_terms_in_body_counts_lower(self) -> Counter:
+        return extract.get_search_terms_count(self.raw_source, False)
+
     def as_dict(self) -> dict:
         return {
             "title": self.title_or_incipit,

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -5,6 +5,7 @@ from collections import Counter
 import datetime
 from . import extract
 import pathlib
+from textwrap import dedent, shorten
 from typing import Union
 
 class NexisDocument(object):
@@ -14,6 +15,12 @@ class NexisDocument(object):
         """Create a NexisDocument from GFM text"""
         self.raw_source = raw_source
 
+    def __str__(self):
+        result = """\
+        {}
+        ---""".format(self.title_or_incipit)
+        return dedent(result)
+
     @property
     def body(self) -> str:
         return extract.get_body(self.raw_source)
@@ -21,6 +28,15 @@ class NexisDocument(object):
     @property
     def title(self) -> str:
         return extract.get_title(self.raw_source)
+
+    @property
+    def title_or_incipit(self) -> str:
+        if self.title:
+            return self.title
+        elif self.body:
+            return shorten(self.body, width=60)
+        else:
+            return "[No title or body]"
 
     @property
     def length(self) -> int:

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -2,20 +2,40 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Representation of Nexis Uni documents"""
 import datetime
+from . import extract
+import pathlib
+from typing import Union
 
 class NexisDocument(object):
-    body: str
-    title: str
-    length: int
-    date_str: str
-    date: datetime.datetime
-    raw_source: str
+    """A document with typical properties"""
 
     def __init__(self, raw_source: str):
         """Create a NexisDocument from GFM text"""
         self.raw_source = raw_source
-        self.body = None
-        self.title = None
-        self.length = None
-        self.date_str = None
-        self.date = None
+
+    @property
+    def body(self) -> str:
+        return extract.get_body(self.raw_source)
+
+    @property
+    def title(self) -> str:
+        return extract.get_title(self.raw_source)
+
+    @property
+    def length(self) -> int:
+        return extract.get_length(self.raw_source)
+
+    @property
+    def date(self) -> datetime.datetime:
+        return extract.get_date(self.raw_source)
+
+    @property
+    def date_str(self) -> str:
+        return extract.get_date_str(self.raw_source)
+
+
+def doc_from_file(file_name: Union[str, pathlib.Path]) -> NexisDocument:
+    """Create a NexisDocument by loading a GFM file"""
+    with open(file_name, "r", encoding="utf-8") as fh:
+        raw_source = fh.read()
+    return NexisDocument(raw_source)

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -65,6 +65,16 @@ class NexisDocument(object):
     def search_terms_in_body_counts(self) -> Counter:
         return extract.get_search_terms_count(self.raw_source)
 
+    def as_dict(self) -> dict:
+        return {
+            "title": self.title_or_incipit,
+            "publication": self.publication if self.publication else "[no publication]",
+            "date": self.date.isoformat() if self.date else "[no date]",
+            "section": self.section if self.section else "[no section]",
+            "byline": self.byline if self.byline else "[no byline]",
+            "length": self.length if self.length else "[no length]",
+        }
+
 
 def doc_from_file(file_name: Union[str, pathlib.Path]) -> NexisDocument:
     """Create a NexisDocument by loading a GFM file"""

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Extract information from documents"""
+import datetime
+import pathlib
+import re
+
+month_by_name = {
+    "januari": 1,
+    "februari": 2,
+    "maart": 3,
+    "april": 4,
+    "mei": 5,
+    "juni": 6,
+    "juli": 7,
+    "augustus": 8,
+    "september": 9,
+    "oktober": 10,
+    "november": 11,
+    "december": 12,
+}
+
+class NexisDocument:
+
+    def __init__(self, file_name):
+        """Create a NexisDocument by loading a GFM file"""
+        with open(file_name, "r", encoding="utf-8") as fh:
+            self.raw_source = fh.read()
+
+    @property
+    def body(self):
+
+        body_start = """**Body**"""
+        body_start_index = self.raw_source.index(body_start) + len(body_start)
+        body_end = """**Load-Date:**"""
+        body_end_index = self.raw_source.index(body_end)
+        return self.raw_source[body_start_index:body_end_index].strip()
+
+    @property
+    def title(self):
+        title = re.search(r"# \[\*{3}<u>(.+)</u>\*{3}\]", self.raw_source)
+        if title:
+            return title.group(1).replace("</u>*** ***<u>", " ")
+
+    @property
+    def length(self):
+        length = re.search(r"\*\*Length:\*\*\s(\d+)\swords", self.raw_source)
+        if length:
+            return int(length.group(1))
+
+    @property
+    def date(self):
+        date = re.search(r"(\d\d?) (\w+) (\d{4}) \w+dag", self.raw_source)
+        if date:
+            year = int(date.group(3))
+            month = month_by_name.get(date.group(2).lower())
+            day = int(date.group(1))
+            return datetime.datetime(year, month, day)
+
+    @property
+    def date_str(self):
+        date = re.search(r"(\d\d? \w+ \d{4} \w+dag)", self.raw_source)
+        if date:
+            return date.group(1)

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Representation of Nexis Uni documents"""
+from collections import Counter
 import datetime
 from . import extract
 import pathlib
@@ -36,6 +37,17 @@ class NexisDocument(object):
     @property
     def byline(self) -> str:
         return extract.get_byline(self.raw_source)
+
+    @property
+    def section(self) -> str:
+        return extract.get_section(self.raw_source)
+
+    @property
+    def publication(self) -> str:
+        return extract.get_publication(self.raw_source)
+
+    def search_terms_in_body_counts(self) -> Counter:
+        return extract.get_search_terms_count(self.raw_source)
 
 
 def doc_from_file(file_name: Union[str, pathlib.Path]) -> NexisDocument:

--- a/nexis_analysis/document.py
+++ b/nexis_analysis/document.py
@@ -33,6 +33,10 @@ class NexisDocument(object):
     def date_str(self) -> str:
         return extract.get_date_str(self.raw_source)
 
+    @property
+    def byline(self) -> str:
+        return extract.get_byline(self.raw_source)
+
 
 def doc_from_file(file_name: Union[str, pathlib.Path]) -> NexisDocument:
     """Create a NexisDocument by loading a GFM file"""

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -82,6 +82,17 @@ def get_date_str(raw_source):
     if date:
         return date.group(0)
 
+def get_load_date(raw_source):
+    date = re.search(r"\*\*Load-Date:\*\*\s(?P<month>[a-z]+?)\s(?P<day>\d\d?),\s(?P<year>\d{4})", raw_source, re.I)
+    if date:
+        year = int(date.group("year"))
+        month = month_by_name.get(date.group("month").lower())
+        day = int(date.group("day"))
+        if month is None:
+            print(date.group("month"), "matched as month")
+            return
+        return datetime.datetime(year, month, day)
+
 def get_byline(raw_source):
     byline = re.search(r"\*\*Byline:\*\*\s(.+)\n", raw_source)
     if byline:

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -71,6 +71,11 @@ def get_section(raw_source):
     if section:
         return section.group(1)
 
+def get_publication(raw_source):
+    lines = raw_source.split("\n")
+    if len(lines) > 4:
+        return lines[4]
+
 def get_search_terms_count(raw_source) -> Counter:
     body_text = get_body(raw_source)
     terms = re.findall(r"\*{3}<u>([^<]+)</u>\*{3}", body_text) if body_text else []

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -39,7 +39,7 @@ def get_body(raw_source):
 def get_title(raw_source):
     title = re.search(r"# \[\*{3}<u>(.+)</u>\*{3}\]", raw_source)
     if title:
-        return title.group(1).replace("</u>*** ***<u>", " ")
+        return re.sub(r"</u>.+?<u>", " ", title.group(1))
 
 
 def get_length(raw_source):

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -55,3 +55,8 @@ def get_date_str(raw_source):
     date = re.search(r"(\d\d? \w+ \d{4} \w+dag)", raw_source)
     if date:
         return date.group(1)
+
+def get_byline(raw_source):
+    byline = re.search(r"\*\*Byline:\*\*\s(.+)\n", raw_source)
+    if byline:
+        return byline.group(1)

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -97,7 +97,9 @@ def get_publication(raw_source):
     if len(lines) > 4:
         return lines[4]
 
-def get_search_terms_count(raw_source) -> Counter:
+def get_search_terms_count(raw_source, case_sensitive=True) -> Counter:
     body_text = get_body(raw_source)
     terms = re.findall(r"\*{3}<u>([^<]+)</u>\*{3}", body_text) if body_text else []
+    if not case_sensitive:
+        terms = [t.lower() for t in terms]
     return Counter(terms)

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -72,7 +72,7 @@ def get_section(raw_source):
         return section.group(1)
 
 def get_publication(raw_source):
-    lines = raw_source.split("\n")
+    lines = raw_source.splitlines()
     if len(lines) > 4:
         return lines[4]
 

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Extract information from documents"""
+import datetime
+from . import document
+import pathlib
+import re
+from typing import Union
+
+month_by_name = {
+    "januari": 1,
+    "februari": 2,
+    "maart": 3,
+    "april": 4,
+    "mei": 5,
+    "juni": 6,
+    "juli": 7,
+    "augustus": 8,
+    "september": 9,
+    "oktober": 10,
+    "november": 11,
+    "december": 12,
+}
+
+
+
+def doc_from_file(file_name: Union[str, pathlib.Path]) -> document.NexisDocument:
+    """Create a NexisDocument by loading a GFM file"""
+    with open(file_name, "r", encoding="utf-8") as fh:
+        raw_source = fh.read()
+    doc = document.NexisDocument(raw_source)
+    doc.body = get_body(raw_source)
+    doc.title = get_title(raw_source)
+    doc.date = get_date(raw_source)
+    doc.date_str = get_date_str(raw_source)
+    doc.length = get_length(raw_source)
+    return doc
+
+
+def get_body(raw_source):
+
+    body_start = """**Body**"""
+    body_start_index = raw_source.index(body_start) + len(body_start)
+    body_end = """**Load-Date:**"""
+    body_end_index = raw_source.index(body_end)
+    return raw_source[body_start_index:body_end_index].strip()
+
+
+def get_title(raw_source):
+    title = re.search(r"# \[\*{3}<u>(.+)</u>\*{3}\]", raw_source)
+    if title:
+        return title.group(1).replace("</u>*** ***<u>", " ")
+
+
+def get_length(raw_source):
+    length = re.search(r"\*\*Length:\*\*\s(\d+)\swords", raw_source)
+    if length:
+        return int(length.group(1))
+
+
+def get_date(raw_source):
+    date = re.search(r"(\d\d?) (\w+) (\d{4}) \w+dag", raw_source)
+    if date:
+        year = int(date.group(3))
+        month = month_by_name.get(date.group(2).lower())
+        day = int(date.group(1))
+        return datetime.datetime(year, month, day)
+
+def get_date_str(raw_source):
+    date = re.search(r"(\d\d? \w+ \d{4} \w+dag)", raw_source)
+    if date:
+        return date.group(1)

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Extract information from documents"""
 import datetime
-from . import document
 import pathlib
 import re
-from typing import Union
 
 month_by_name = {
     "januari": 1,
@@ -22,28 +20,15 @@ month_by_name = {
     "december": 12,
 }
 
-
-
-def doc_from_file(file_name: Union[str, pathlib.Path]) -> document.NexisDocument:
-    """Create a NexisDocument by loading a GFM file"""
-    with open(file_name, "r", encoding="utf-8") as fh:
-        raw_source = fh.read()
-    doc = document.NexisDocument(raw_source)
-    doc.body = get_body(raw_source)
-    doc.title = get_title(raw_source)
-    doc.date = get_date(raw_source)
-    doc.date_str = get_date_str(raw_source)
-    doc.length = get_length(raw_source)
-    return doc
-
-
 def get_body(raw_source):
-
-    body_start = """**Body**"""
-    body_start_index = raw_source.index(body_start) + len(body_start)
-    body_end = """**Load-Date:**"""
-    body_end_index = raw_source.index(body_end)
-    return raw_source[body_start_index:body_end_index].strip()
+    try:
+        body_start = """**Body**"""
+        body_start_index = raw_source.index(body_start) + len(body_start)
+        body_end = """**Load-Date:**"""
+        body_end_index = raw_source.index(body_end)
+        return raw_source[body_start_index:body_end_index].strip()
+    except ValueError:
+        return None
 
 
 def get_title(raw_source):

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -19,6 +19,14 @@ month_by_name = {
     "oktober": 10,
     "november": 11,
     "december": 12,
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "october": 10,
 }
 
 def get_body(raw_source):
@@ -49,17 +57,24 @@ def get_length(raw_source):
 
 
 def get_date(raw_source):
-    date = re.search(r"(\d\d?) (\w+) (\d{4}) \w+dag", raw_source)
+    date = re.search(r"(?P<day>\d\d?) (?P<month>\w+) (?P<year>\d{4}) \w+dag", raw_source)
     if date:
-        year = int(date.group(3))
-        month = month_by_name.get(date.group(2).lower())
-        day = int(date.group(1))
+        year = int(date.group("year"))
+        month = month_by_name.get(date.group("month").lower())
+        day = int(date.group("day"))
         return datetime.datetime(year, month, day)
+    else:
+        date = re.search(r"(?<!\*\*\s)(?P<month>\w+)\s(?P<day>\d\d?),\s(?P<year>\d{4})", raw_source)
+        if date:
+            year = int(date.group("year"))
+            month = month_by_name.get(date.group("month").lower())
+            day = int(date.group("day"))
+            return datetime.datetime(year, month, day)
 
 def get_date_str(raw_source):
-    date = re.search(r"(\d\d? \w+ \d{4} \w+dag)", raw_source)
+    date = re.search(r"\d\d? \w+ \d{4} \w+dag|(?<!\*\*\s)\w+ \d\d?, \d{4}", raw_source)
     if date:
-        return date.group(1)
+        return date.group(0)
 
 def get_byline(raw_source):
     byline = re.search(r"\*\*Byline:\*\*\s(.+)\n", raw_source)

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -24,11 +24,15 @@ def get_body(raw_source):
     try:
         body_start = """**Body**"""
         body_start_index = raw_source.index(body_start) + len(body_start)
+    except ValueError:
+        body_start_index = 0
+
+    try:
         body_end = """**Load-Date:**"""
         body_end_index = raw_source.index(body_end)
-        return raw_source[body_start_index:body_end_index].strip()
     except ValueError:
-        return None
+        body_end_index = len(raw_source)
+    return raw_source[body_start_index:body_end_index].strip()
 
 
 def get_title(raw_source):

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Extract information from documents"""
+from collections import Counter
 import datetime
 import pathlib
 import re
@@ -64,3 +65,8 @@ def get_byline(raw_source):
     byline = re.search(r"\*\*Byline:\*\*\s(.+)\n", raw_source)
     if byline:
         return byline.group(1)
+
+def get_search_terms_count(raw_source) -> Counter:
+    body_text = get_body(raw_source)
+    terms = re.findall(r"\*{3}<u>([^<]+)</u>\*{3}", body_text) if body_text else []
+    return Counter(terms)

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -66,6 +66,11 @@ def get_byline(raw_source):
     if byline:
         return byline.group(1)
 
+def get_section(raw_source):
+    section = re.search(r"\*\*Section:\*\*\s(.+)\n", raw_source)
+    if section:
+        return section.group(1)
+
 def get_search_terms_count(raw_source) -> Counter:
     body_text = get_body(raw_source)
     terms = re.findall(r"\*{3}<u>([^<]+)</u>\*{3}", body_text) if body_text else []

--- a/nexis_analysis/extract.py
+++ b/nexis_analysis/extract.py
@@ -57,22 +57,28 @@ def get_length(raw_source):
 
 
 def get_date(raw_source):
-    date = re.search(r"(?P<day>\d\d?) (?P<month>\w+) (?P<year>\d{4}) \w+dag", raw_source)
+    date = re.search(r"(?<!\*\*\s)\b(?P<day>\d\d?)\s(?P<month>[a-z]+?)\s(?P<year>\d{4})( \w+dag)?", raw_source, re.I)
     if date:
         year = int(date.group("year"))
         month = month_by_name.get(date.group("month").lower())
         day = int(date.group("day"))
+        if month is None:
+            print(date.group("month"), "matched as month")
+            return
         return datetime.datetime(year, month, day)
     else:
-        date = re.search(r"(?<!\*\*\s)(?P<month>\w+)\s(?P<day>\d\d?),\s(?P<year>\d{4})", raw_source)
+        date = re.search(r"(?<!\*\*\s)\b(?P<month>[a-z]+?)\s(?P<day>\d\d?),\s(?P<year>\d{4})", raw_source, re.I)
         if date:
             year = int(date.group("year"))
             month = month_by_name.get(date.group("month").lower())
             day = int(date.group("day"))
+            if month is None:
+                print(date.group("month"), "matched as month")
+                return
             return datetime.datetime(year, month, day)
 
 def get_date_str(raw_source):
-    date = re.search(r"\d\d? \w+ \d{4} \w+dag|(?<!\*\*\s)\w+ \d\d?, \d{4}", raw_source)
+    date = re.search(r"\d\d? \w+ \d{4} \w+dag|(?<!\*\*\s)\b\w+ \d\d?, \d{4}", raw_source)
     if date:
         return date.group(0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "nexis-analysis"
 description = "Analyse data from Nexis Uni"
 version = "0.1.0"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "GPL-3.0-or-later"
 keywords = []
 authors = [
@@ -19,7 +19,6 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -49,7 +48,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=nexis_
 no-cov = "cov --no-cov"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["38", "39", "310", "311"]
+python = ["39", "310", "311"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nexis-analysis"
 description = "Analyse data from Nexis Uni"
-version = "0.1.0"
+version = "0.2.0"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "GPL-3.0-or-later"
@@ -35,8 +35,8 @@ Documentation = "https://leidenuniversitylibrary.github.io/nexis-analysis/"
 Issues = "https://github.com/LeidenUniversityLibrary/nexis-analysis/issues"
 Source = "https://github.com/LeidenUniversityLibrary/nexis-analysis"
 
-# [project.scripts]
-
+[project.scripts]
+nexis = "nexis_analysis.cli:main"
 
 [tool.hatch.envs.test]
 dependencies = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -22,6 +22,7 @@ def test_document_init(text):
     assert doc.title is None
     assert doc.date is None
     assert doc.date_str is None
+    assert doc.byline is None
 
 def test_doc_from_file():
     doc = document.doc_from_file(get_path("test1.md"))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Test that metadata are correctly extracted from documents"""
+
+from nexis_analysis import document, extract
+import pytest
+
+@pytest.fixture()
+def text():
+    yield "This is a piece of text."
+
+def test_document_init(text):
+    doc = document.NexisDocument(text)
+
+    assert doc.raw_source == text
+    assert doc.body is None
+    assert doc.length is None
+    assert doc.title is None
+    assert doc.date is None
+    assert doc.date_str is None

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -57,5 +57,6 @@ def test_empty_doc():
     assert doc.section is None
     assert doc.publication is None
     assert doc.search_terms_in_body_counts() == Counter()
+    assert doc.search_terms_in_body_counts_lower() == Counter()
     assert doc.title_or_incipit == "[No title or body]"
     assert "[No title or body]" in str(doc)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -28,6 +28,7 @@ def test_document_init(text):
     assert doc.search_terms_in_body_counts() == Counter()
     assert doc.title_or_incipit == text
     assert text in str(doc)
+    assert doc.as_dict()
 
 def test_doc_from_file():
     doc = document.doc_from_file(get_path("test1.md"))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,7 +3,11 @@
 """Test that metadata are correctly extracted from documents"""
 
 from nexis_analysis import document, extract
+import pathlib
 import pytest
+
+def get_path(relative_path):
+    return pathlib.Path("tests/fixtures", relative_path).resolve()
 
 @pytest.fixture()
 def text():
@@ -18,3 +22,7 @@ def test_document_init(text):
     assert doc.title is None
     assert doc.date is None
     assert doc.date_str is None
+
+def test_doc_from_file():
+    doc = document.doc_from_file(get_path("test1.md"))
+    assert doc.body is not None

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -17,7 +17,7 @@ def test_document_init(text):
     doc = document.NexisDocument(text)
 
     assert doc.raw_source == text
-    assert doc.body is None
+    assert doc.body is not None
     assert doc.length is None
     assert doc.title is None
     assert doc.date is None
@@ -27,3 +27,8 @@ def test_document_init(text):
 def test_doc_from_file():
     doc = document.doc_from_file(get_path("test1.md"))
     assert doc.body is not None
+    assert doc.length is not None
+    assert doc.title is not None
+    assert doc.date is not None
+    assert doc.date_str is not None
+    assert doc.byline is not None

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Test that metadata are correctly extracted from documents"""
-
-from nexis_analysis import document, extract
+from collections import Counter
+from nexis_analysis import document
 import pathlib
 import pytest
 
@@ -23,6 +23,9 @@ def test_document_init(text):
     assert doc.date is None
     assert doc.date_str is None
     assert doc.byline is None
+    assert doc.section is None
+    assert doc.publication is None
+    assert doc.search_terms_in_body_counts() == Counter()
 
 def test_doc_from_file():
     doc = document.doc_from_file(get_path("test1.md"))
@@ -32,3 +35,6 @@ def test_doc_from_file():
     assert doc.date is not None
     assert doc.date_str is not None
     assert doc.byline is not None
+    assert doc.section is not None
+    assert doc.publication is not None
+    assert len(doc.search_terms_in_body_counts()) == 1

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -26,6 +26,8 @@ def test_document_init(text):
     assert doc.section is None
     assert doc.publication is None
     assert doc.search_terms_in_body_counts() == Counter()
+    assert doc.title_or_incipit == text
+    assert text in str(doc)
 
 def test_doc_from_file():
     doc = document.doc_from_file(get_path("test1.md"))
@@ -38,3 +40,21 @@ def test_doc_from_file():
     assert doc.section is not None
     assert doc.publication is not None
     assert len(doc.search_terms_in_body_counts()) == 1
+    assert doc.title_or_incipit == doc.title
+
+def test_empty_doc():
+    text = ""
+    doc = document.NexisDocument(text)
+
+    assert doc.raw_source == text
+    assert doc.body is not None
+    assert doc.length is None
+    assert doc.title is None
+    assert doc.date is None
+    assert doc.date_str is None
+    assert doc.byline is None
+    assert doc.section is None
+    assert doc.publication is None
+    assert doc.search_terms_in_body_counts() == Counter()
+    assert doc.title_or_incipit == "[No title or body]"
+    assert "[No title or body]" in str(doc)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -130,3 +130,14 @@ def test_get_publication(document, publication):
 )
 def test_term_in_body_counts(document, counts):
     assert extract.get_search_terms_count(document) == counts
+
+@pytest.mark.parametrize(
+    "document,counts",
+    [
+        ("***<u>mijn KEYword</u>***", Counter({'mijn keyword': 1})),
+        (load_doc("test1.md"), Counter({'niet-bancaire': 1})),
+        (load_doc("test2.md"), Counter({'schaduwbank': 1, 'schaduwbanken': 2, 'schaduwbankieren': 3,})),
+    ]
+)
+def test_term_in_body_counts_lower(document, counts):
+    assert extract.get_search_terms_count(document, False) == counts

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Test that metadata are correctly extracted from documents"""
+import datetime
+from nexis_analysis import document
+import pathlib
+import pytest
+
+def load_doc(path):
+    return document.NexisDocument(str(pathlib.Path("tests/fixtures", path).resolve()))
+
+@pytest.fixture(params=["test1.md", "test2.md"])
+def doc(request):
+    yield load_doc(request.param)
+
+
+def test_body(doc):
+    assert doc.body
+    assert "**Body**" not in doc.body
+
+@pytest.mark.parametrize(
+    "document,title",
+    [
+        (load_doc("test1.md"), "Veldslag om smartphone als mobiele bank"),
+        (load_doc("test2.md"), "Schaduwbankieren valt mee, vindt Nederlandsche Bank"),
+    ]
+)
+def test_title(document, title):
+    assert document.title
+    assert "**" not in document.title
+    assert document.title == title
+
+@pytest.mark.parametrize(
+    "document,length",
+    [
+        (load_doc("test1.md"), 952),
+        (load_doc("test2.md"), 245),
+    ]
+)
+def test_length(document, length):
+    assert document.length
+    assert isinstance(document.length, int)
+    assert document.length == length
+
+@pytest.mark.parametrize(
+    "document,date_str,date",
+    [
+        (load_doc("test1.md"), "4 oktober 2017 woensdag", datetime.datetime(2017, 10, 4)),
+        (load_doc("test2.md"), "30 november 2012 vrijdag", datetime.datetime(2012, 11, 30)),
+    ]
+)
+def test_date(document, date_str, date):
+    assert document.date == date
+    assert document.date_str == date_str

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -67,3 +67,16 @@ def test_get_date(document, date):
 )
 def test_get_date_str(document, date_str):
     assert extract.get_date_str(document) == date_str
+
+@pytest.mark.parametrize(
+    "document,byline",
+    [
+        (load_doc("test1.md"), "DOOR MARC VAN DEN EERENBEEMT"),
+        (load_doc("test2.md"), None),
+    ]
+)
+def test_get_byline(document, byline):
+    if byline is None:
+        assert extract.get_byline(document) is None
+    else:
+        assert extract.get_byline(document) == byline

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -84,6 +84,19 @@ def test_get_byline(document, byline):
         assert extract.get_byline(document) == byline
 
 @pytest.mark.parametrize(
+    "document,section",
+    [
+        (load_doc("test1.md"), "Economie; Blz. 28, 29"),
+        (load_doc("test2.md"), None),
+    ]
+)
+def test_get_section(document, section):
+    if section is None:
+        assert extract.get_section(document) is None
+    else:
+        assert extract.get_section(document) == section
+
+@pytest.mark.parametrize(
     "document,counts",
     [
         ("***<u>mijn KEYword</u>***", Counter({'mijn KEYword': 1})),

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -56,6 +56,7 @@ def test_get_length(document, length):
     [
         (load_doc("test1.md"), datetime.datetime(2017, 10, 4)),
         (load_doc("test2.md"), datetime.datetime(2012, 11, 30)),
+        ("August 5, 2022 6:43 PM GMT", datetime.datetime(2022, 8, 5)),
     ]
 )
 def test_get_date(document, date):
@@ -66,6 +67,7 @@ def test_get_date(document, date):
     [
         (load_doc("test1.md"), "4 oktober 2017 woensdag"),
         (load_doc("test2.md"), "30 november 2012 vrijdag"),
+        ("augustus 5, 2022 6:43 PM GMT", "augustus 5, 2022"),
     ]
 )
 def test_get_date_str(document, date_str):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -20,6 +20,7 @@ def test_get_body(doc):
     body = extract.get_body(doc)
     assert body
     assert "**Body**" not in body
+    assert "**Load-Date**" not in body
 
 
 @pytest.mark.parametrize(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -97,6 +97,20 @@ def test_get_section(document, section):
         assert extract.get_section(document) == section
 
 @pytest.mark.parametrize(
+    "document,publication",
+    [
+        (load_doc("test1.md"), "de Volkskrant"),
+        (load_doc("test2.md"), "De Gooi- en Eemlander"),
+        ("No publication here", None),
+    ]
+)
+def test_get_publication(document, publication):
+    if publication is None:
+        assert extract.get_publication(document) is None
+    else:
+        assert extract.get_publication(document) == publication
+
+@pytest.mark.parametrize(
     "document,counts",
     [
         ("***<u>mijn KEYword</u>***", Counter({'mijn KEYword': 1})),

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -29,6 +29,7 @@ def test_get_body(doc):
     [
         (load_doc("test1.md"), "Veldslag om smartphone als mobiele bank"),
         (load_doc("test2.md"), "Schaduwbankieren valt mee, vindt Nederlandsche Bank"),
+        ("# [***<u>Stresstest</u>***](https://advance.lexis.com/api/document?collection=news&id=urn:contentItem:601X-HCR1-JC5G-10P8-00000-00&context=1516831) [***<u>CPB: coronacrisis kan financiële sector schaden</u>***](https://advance.lexis.com/api/document?collection=news&id=urn:contentItem:601X-HCR1-JC5G-10P8-00000-00&context=1516831)", "Stresstest CPB: coronacrisis kan financiële sector schaden"),
     ]
 )
 def test_get_title(document, title):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present Leiden University Libraries <beheer@library.leidenuniv.nl>
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Test that metadata are correctly extracted from documents"""
+from collections import Counter
 import datetime
 from nexis_analysis import extract
 import pathlib
@@ -81,3 +82,14 @@ def test_get_byline(document, byline):
         assert extract.get_byline(document) is None
     else:
         assert extract.get_byline(document) == byline
+
+@pytest.mark.parametrize(
+    "document,counts",
+    [
+        ("***<u>mijn KEYword</u>***", Counter({'mijn KEYword': 1})),
+        (load_doc("test1.md"), Counter({'niet-bancaire': 1})),
+        (load_doc("test2.md"), Counter({'Schaduwbanken': 1, 'Schaduwbankieren': 1, 'schaduwbank': 1, 'schaduwbanken': 1, 'schaduwbankieren': 2,})),
+    ]
+)
+def test_term_in_body_counts(document, counts):
+    assert extract.get_search_terms_count(document) == counts

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -61,6 +61,7 @@ def test_get_length(document, length):
         ("Het Parool\n\nNovember 3, 2000", datetime.datetime(2000, 11, 3)),
         ("(+31) 34 379 9909", None),
         ("**Section:** Financieel: Scorpio; N.1 van 2006, J.9; P.41; fdw", None),
+        ("Nov 23, 2023", None),
     ]
 )
 def test_get_date(document, date):
@@ -68,6 +69,25 @@ def test_get_date(document, date):
         assert extract.get_date(document) is None
     else:
         assert extract.get_date(document) == date
+
+@pytest.mark.parametrize(
+    "document,date",
+    [
+        (load_doc("test1.md"), datetime.datetime(2017, 10, 3)),
+        (load_doc("test2.md"), datetime.datetime(2012, 11, 30)),
+        ("August 5, 2022 6:43 PM GMT", None),
+        ("**Load-Date:** Apr 6, 2012", None),
+        ("**Load-Date:** November 3, 2000", datetime.datetime(2000, 11, 3)),
+        ("(+31) 34 379 9909", None),
+        ("**Section:** Financieel: Scorpio; N.1 van 2006, J.9; P.41; fdw", None),
+        ("Nov 23, 2023", None),
+    ]
+)
+def test_get_load_date(document, date):
+    if date is None:
+        assert extract.get_load_date(document) is None
+    else:
+        assert extract.get_load_date(document) == date
 
 @pytest.mark.parametrize(
     "document,date_str",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -57,10 +57,17 @@ def test_get_length(document, length):
         (load_doc("test1.md"), datetime.datetime(2017, 10, 4)),
         (load_doc("test2.md"), datetime.datetime(2012, 11, 30)),
         ("August 5, 2022 6:43 PM GMT", datetime.datetime(2022, 8, 5)),
+        ("6 april 2012", datetime.datetime(2012, 4, 6)),
+        ("Het Parool\n\nNovember 3, 2000", datetime.datetime(2000, 11, 3)),
+        ("(+31) 34 379 9909", None),
+        ("**Section:** Financieel: Scorpio; N.1 van 2006, J.9; P.41; fdw", None),
     ]
 )
 def test_get_date(document, date):
-    assert extract.get_date(document) == date
+    if date is None:
+        assert extract.get_date(document) is None
+    else:
+        assert extract.get_date(document) == date
 
 @pytest.mark.parametrize(
     "document,date_str",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -21,9 +21,6 @@ def test_get_body(doc):
     assert body
     assert "**Body**" not in body
 
-def test_doc_from_file():
-    doc = extract.doc_from_file(get_path("test1.md"))
-    assert doc.body is not None
 
 @pytest.mark.parametrize(
     "document,title",


### PR DESCRIPTION
This introduces the command-line tools for extracting metadata (title, byline, dates, etc.) from the converted documents and for creating an overview of marked up search phrases found in the body of the documents.

Most of this code is covered by unit tests, although these tests rely on two test files that are not included (see #6 for a discussion).